### PR TITLE
fix: don't mix dates

### DIFF
--- a/pd_list.py
+++ b/pd_list.py
@@ -18,7 +18,7 @@ from datetime import date
 from pywikibot import pagegenerators as pg
 
 # pd_year = date.today().year - 70
-pd_year_today = 2021
+pd_year_today = 2022
 pd_year = pd_year_today - 71
 pd_year_1 = (pd_year + 1)
 print(pd_year)
@@ -38,7 +38,7 @@ author_qlist = ("Q36180", "Q6625963", "Q36834", "Q49757", "Q214917", "Q4853732",
 authors = dict()
 wikitext = """Quando o [[direito autoral]] de uma obra expira, ela entra em '''[[domínio público]]'''.
 Em Portugal, uma obra entra em [[domínio público]] 70 anos após a morte do autor.<ref>{{citar web|url=http://www.pgdlisboa.pt/leis/lei_mostra_articulado.php?artigo_id=484A0031&nid=484&tabela=leis&pagina=1&ficha=1&so_miolo=&nversao=#artigo |título=CÓDIGO DO DIREITO DE AUTOR E DOS DIREITOS CONEXOS| acessodata=2018-12-29}}</ref>
-Segue-se uma '''lista de autores Portugueses cujas obras entram em domínio público em 2022'''.
+Segue-se uma '''lista de autores Portugueses cujas obras entram em domínio público em """ + str(pd_year_today) +"""'''.
 {| class="wikitable sortable" border="1" style="border-spacing:0; style="width:100%;"
 ! Nome
 ! Data de Nascimento


### PR DESCRIPTION
We should be querying for the year 2022, according to the text we're
generating. Also, we're now using the year variable to have it all in
just one place (and when we decide to run this for 2023, we just need
to update one variable).

In the future we might want to get the year as a parameter.