### PR TITLE
Actualizada categoria

### DIFF
--- a/pd_list.py
+++ b/pd_list.py
@@ -116,7 +116,7 @@ wikitext = wikitext + """\n|}
 ==Referências==
 {{reflist}}
 
-[[Categoria:Domínio público]]
+[[Categoria:Listas sobre domínio público]]
 [[Categoria:%s]]""" % (pd_year_today)
 print(wikitext)
 


### PR DESCRIPTION
A lista publicada de 2023 foi actualizada na wikipédia, para se passar a usar a Categoria "Listas sobre domínio público" em vez da categoria "Domínio público":

https://pt.wikipedia.org/w/index.php?title=Lista_de_autores_portugueses_que_entram_em_dom%C3%ADnio_p%C3%BAblico_em_2023&diff=65166284&oldid=65011378

Este commit faz a mesma alteração no bot, para que listas futuras usem a mesma categoria.