### PR TITLE
verifica se item tem "multiple languages" label

### DIFF
--- a/pd_list.py
+++ b/pd_list.py
@@ -73,15 +73,18 @@ for item in generator:
 	try:
 		a_name = item.getSitelink('ptwiki')
 	except pywikibot.exceptions.NoSiteLinkError:
-		try:
+		if 'pt' in item_dict["labels"].keys():
 			a_name = item_dict["labels"]['pt']
-		except:
+		elif 'mul' in item_dict["labels"].keys():
+			a_name = item_dict["labels"]['mul']
+		elif 'en' in item_dict["labels"].keys():
 			a_name = item_dict["labels"]['en']
-
-	except:
-		a_name = item_dict["labels"]['en']
-
-		print("no pt label")
+		else:
+			a_name = ""
+			print ("no label found")
+			# DEBUG:
+			print ("D: the item_dict:")
+			print (item_dict)
 
 	# Falta obter página no wikisource
 	# try:


### PR DESCRIPTION
O nome do autor fica:
* O nome da página na wikipédia Portuguesa, se houver
* caso contrário, o que está na Wikidata, em Português
* caso contrário, o que está na Wikidata, para "multiple languages"
* caso contrário, o que está na Wikidata, para Inglês
* caso contrário, vazio (e é impressa informação de debug)